### PR TITLE
Fixed for Python 3.4.3 and uTorrent 3.4.3

### DIFF
--- a/utorrent/connection.py
+++ b/utorrent/connection.py
@@ -54,8 +54,8 @@ class Connection:
 		try:
 			while retries < max_retries or utserver_retry:
 				try:
-					self._request.add_data( data )
-					self._connection.request( self._request.get_method( ), self._request.get_selector( ) + loc, self._request.get_data( ), headers )
+					self._request.data = data
+					self._connection.request( self._request.get_method( ), self._request.selector + loc, self._request.data, headers )
 					resp = self._connection.getresponse( )
 					if resp.status == 400:
 						last_e = utorrent.uTorrentError( resp.read( ).decode( "utf8" ).strip( ) )
@@ -215,7 +215,7 @@ class Connection:
 					raise e
 			if ver.product == "server":
 				return utorrent.uTorrent.LinuxServer( self, ver )
-			elif ver.product == "desktop":
+			elif ver.product == "desktop" or ver.product == "PRODUCT_CODE":
 				if ver.major == 3:
 					return utorrent.uTorrent.Falcon( self, ver )
 				else:

--- a/utorrentctl.py
+++ b/utorrentctl.py
@@ -177,7 +177,7 @@ parser.add_option( "--limit", dest = "limit", default = 0, help = "limit the num
 opts, args = parser.parse_args( )
 
 try:
-
+	print(opts.host)
 	if opts.host is None: # we didn't supply host in command line => load auth data from config
 		opts.host = utorrentcfg["host"]
 		if opts.user is None:

--- a/utorrentctl.py
+++ b/utorrentctl.py
@@ -177,7 +177,6 @@ parser.add_option( "--limit", dest = "limit", default = 0, help = "limit the num
 opts, args = parser.parse_args( )
 
 try:
-	print(opts.host)
 	if opts.host is None: # we didn't supply host in command line => load auth data from config
 		opts.host = utorrentcfg["host"]
 		if opts.user is None:


### PR DESCRIPTION
Some changes to get this project working with newer versions of Python and uTorrent (3.4.3 in both cases).

urllib.request data and selector are now accessed directly as properties rather than with getters/setters.

uTorrent desktop (i.e. Falcon) 3.4.3 unhelpfully returns a version of "PRODUCT_CODE", this has also been factored in.