### PR TITLE
Fix for default_torrent_format

### DIFF
--- a/config.py.template
+++ b/config.py.template
@@ -6,5 +6,5 @@ utorrentcfg = {
 	"login" : "default_login",
 	"password" : "default_password",
 	"api" : "", # linux, desktop (2.x), falcon (3.x)
-	"default_torrent_format" : "{hash} {status} {progress}% {size} {dl_speed} {ul_speed} {ratio} {peer_info} eta: {eta} {name} {label}",
+	"default_torrent_format" : "{hash_code} {status} {progress}% {size} {dl_speed} {ul_speed} {ratio} {peer_info} eta: {eta} {name} {label}",
 }


### PR DESCRIPTION
In the utorrent/torrent.py, the key for that field is listed as "hash_code", but the config.py.template had it as "hash" which caused and error to be thrown when listing torrents.
